### PR TITLE
Escape class & method name in XML output

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/lodash": "4.14.182",
     "@types/node": "14.14.31",
     "@types/sinon": "7.5.2",
+    "@types/xml2js": "0.4.11",
     "@typescript-eslint/eslint-plugin": "4.22.0",
     "@typescript-eslint/parser": "4.22.0",
     "chai": "4.3.6",
@@ -81,7 +82,8 @@
     "ts-node": "10.2.1",
     "typescript": "4.2.4",
     "webpack": "^5.73.0",
-    "webpack-cli": "^4.10.0"
+    "webpack-cli": "^4.10.0",
+    "xml2js": "0.4.23"
   },
   "config": {
     "commitizen": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ specifiers:
   '@types/lodash': 4.14.182
   '@types/node': 14.14.31
   '@types/sinon': 7.5.2
+  '@types/xml2js': 0.4.11
   '@typescript-eslint/eslint-plugin': 4.22.0
   '@typescript-eslint/parser': 4.22.0
   chai: 4.3.6
@@ -38,6 +39,7 @@ specifiers:
   typescript: 4.2.4
   webpack: ^5.73.0
   webpack-cli: ^4.10.0
+  xml2js: 0.4.23
 
 dependencies:
   '@apexdevtools/sfdx-auth-helper': 1.0.5
@@ -56,6 +58,7 @@ devDependencies:
   '@types/lodash': 4.14.182
   '@types/node': 14.14.31
   '@types/sinon': 7.5.2
+  '@types/xml2js': 0.4.11
   '@typescript-eslint/eslint-plugin': 4.22.0_e3b52a83531895e7febd6ecd5ba813eb
   '@typescript-eslint/parser': 4.22.0_eslint@7.25.0+typescript@4.2.4
   chai: 4.3.6
@@ -76,6 +79,7 @@ devDependencies:
   typescript: 4.2.4
   webpack: 5.74.0_webpack-cli@4.10.0
   webpack-cli: 4.10.0_webpack@5.74.0
+  xml2js: 0.4.23
 
 packages:
 
@@ -1332,6 +1336,12 @@ packages:
 
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
+    dev: true
+
+  /@types/xml2js/0.4.11:
+    resolution: {integrity: sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==}
+    dependencies:
+      '@types/node': 14.14.31
     dev: true
 
   /@types/yargs-parser/21.0.0:

--- a/src/results/ReportGenerator.ts
+++ b/src/results/ReportGenerator.ts
@@ -179,13 +179,14 @@ export class ReportGenerator implements OutputGenerator {
     junit += '        </properties>\n';
     testResults.forEach(test => {
       const success = test.Outcome === 'Pass';
-      let classname = test.ApexClass.Name;
+      let classname = _.escape(test.ApexClass.Name);
       if (test.ApexClass.NamespacePrefix) {
         classname = test.ApexClass.NamespacePrefix + '.' + classname;
       }
-      junit += `        <testcase name="${
-        test.MethodName
-      }" classname="${classname}" time="${msToSeconds(test.RunTime)}">\n`;
+      const methodName = _.escape(test.MethodName);
+      junit += `        <testcase name="${methodName}" classname="${classname}" time="${msToSeconds(
+        test.RunTime
+      )}">\n`;
       if (!success) {
         const message = test.Message ? test.Message : 'No failure message!';
         junit += `            <failure message="${_.escape(message)}">`;


### PR DESCRIPTION
The method name can contain '<compile>' so it needs escaping, I also did the classname just in case. Other elements were already being escaped as needed.  

