### PR TITLE
fix(error): clean exit on ALREADY_IN_PROCESS error

### DIFF
--- a/src/collector/OrgTestMethodCollector.ts
+++ b/src/collector/OrgTestMethodCollector.ts
@@ -46,7 +46,9 @@ export class OrgTestMethodCollector implements TestMethodCollector {
     return this.classNameById;
   }
 
-  async gatherTestMethods(): Promise<Map<string, Set<string>>> {
+  async gatherTestMethods(
+    abort: () => boolean
+  ): Promise<Map<string, Set<string>>> {
     // Query class symbols in chunks
     const loader = new ClassSymbolLoader(
       this.logger,
@@ -62,6 +64,7 @@ export class OrgTestMethodCollector implements TestMethodCollector {
 
     let classInfos: ApexClassInfo[] = [];
     for (const chunk of chunks) {
+      if (abort()) return new Map<string, Set<string>>();
       classInfos = classInfos.concat(await loader.load(chunk));
     }
 

--- a/src/collector/TestMethodCollector.ts
+++ b/src/collector/TestMethodCollector.ts
@@ -9,7 +9,7 @@ import { chunk } from '../query/Chunk';
 
 export interface TestMethodCollector {
   classIdNameMap(): Promise<Map<string, string>>;
-  gatherTestMethods(): Promise<Map<string, Set<string>>>;
+  gatherTestMethods(abort: () => boolean): Promise<Map<string, Set<string>>>;
 }
 
 export async function classIdNameMapFromNames(

--- a/src/command/TestDebugLogs.ts
+++ b/src/command/TestDebugLogs.ts
@@ -41,7 +41,6 @@ export class TestDebugLogs {
       await cmd.run(methodCollector, runner);
     } catch (e) {
       logger.logError(e);
-      throw e;
     }
   }
 
@@ -88,7 +87,7 @@ export class TestDebugLogs {
     this._logger.logMessage(
       'Collecting test methods, this may take some time...'
     );
-    const testMethodMap = await methodCollector.gatherTestMethods();
+    const testMethodMap = await methodCollector.gatherTestMethods(() => false);
     this._logger.logMessage(`Found ${testMethodMap.size} test classes`);
 
     while (testMethodMap.size > 0) {

--- a/src/log/BaseLogger.ts
+++ b/src/log/BaseLogger.ts
@@ -28,9 +28,15 @@ export abstract class BaseLogger implements Logger {
 
   logError(error: MaybeError): void {
     if (error instanceof Error) {
-      this.logMessage(error.message);
-      if (error.stack !== undefined)
-        this.logMessage('Error stack: ' + error.stack);
+      if (error.name == 'ALREADY_IN_PROCESS') {
+        this.logMessage(
+          "One or more of the tests is already queued to run, they can't be requeued"
+        );
+      } else {
+        this.logMessage(error.message);
+        if (error.stack !== undefined)
+          this.logMessage('Error stack: ' + error.stack);
+      }
     } else {
       this.logMessage('Error: ' + JSON.stringify(error));
     }

--- a/src/runner/TestRunner.ts
+++ b/src/runner/TestRunner.ts
@@ -22,7 +22,6 @@ import {
   getStatusPollIntervalMs,
   getTestRunAborter,
   getTestRunTimeoutMins,
-  TestRunnerCallbacks,
   TestRunnerOptions,
 } from './TestOptions';
 import TestStats from './TestStats';

--- a/src/scripts/TestMethods.ts
+++ b/src/scripts/TestMethods.ts
@@ -22,7 +22,7 @@ async function gatherTestMethods(username: string, namespace: string) {
     namespace == 'unmanaged' ? '' : namespace,
     []
   );
-  return await collector.gatherTestMethods();
+  return await collector.gatherTestMethods(() => false);
 }
 
 if (process.argv.length != 4) {

--- a/test/collector/OrgTestMethodCollector.spec.ts
+++ b/test/collector/OrgTestMethodCollector.spec.ts
@@ -200,7 +200,9 @@ describe('messages', () => {
       'foo',
       []
     );
-    const testMethodsByClassName = await testMethodCollector.gatherTestMethods();
+    const testMethodsByClassName = await testMethodCollector.gatherTestMethods(
+      () => false
+    );
 
     expect(testMethodsByClassName.size).to.equal(2);
     expect(testMethodsByClassName.has('FooClass')).to.be.true;
@@ -283,7 +285,9 @@ describe('messages', () => {
       'foo',
       []
     );
-    const testMethodsByClassName = await testMethodCollector.gatherTestMethods();
+    const testMethodsByClassName = await testMethodCollector.gatherTestMethods(
+      () => false
+    );
 
     expect(testMethodsByClassName.size).to.equal(2);
     expect(testMethodsByClassName.has('FooClass')).to.be.true;


### PR DESCRIPTION
### Description of change

The class method detection can now be aborted when the test run fails to start so that the process terminates quickly. We intercept an ALREADY_IN_PROCESS exception and print a better error message rather than dumping the exception.
