### PR TITLE
Exclude test setup methods from results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # test-runner - Changelog
 
+## 3.1.3 - 2024-11-20
+
+* Exclude `@testSetup` methods from `ApexTestResult` queries.
+
 ## 3.1.2 - 2024-04-08
 
 * Set minimum timeout to 30s on polling requests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/test-runner",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Apex parallel test runner with reliability goodness",
   "author": {
     "name": "Apex Dev Tools Team",

--- a/src/collector/ResultCollector.ts
+++ b/src/collector/ResultCollector.ts
@@ -57,7 +57,7 @@ export class ResultCollector {
   ): Promise<ApexTestResult[]> {
     return await QueryHelper.instance(connection).query<ApexTestResult>(
       'ApexTestResult',
-      `AsyncApexJobId='${testRunId}'`,
+      `AsyncApexJobId='${testRunId}' AND IsTestSetup=FALSE`,
       ApexTestResultFields.join(', ')
     );
   }

--- a/src/model/ApexTestResult.ts
+++ b/src/model/ApexTestResult.ts
@@ -2,19 +2,26 @@
  * Copyright (c) 2019, FinancialForce.com, inc. All rights reserved.
  */
 
+/*
+ Unselected fields:
+  ApexLogId: string;
+  ApexTestRunResultId: string;
+  IsTestSetup: boolean;
+*/
+
 export const ApexTestResultFields = [
-  'Id',
-  'QueueItemId',
-  'AsyncApexJobId',
-  'Outcome',
-  'MethodName',
-  'Message',
-  'StackTrace',
-  'RunTime',
-  'TestTimestamp',
   'ApexClass.Id',
   'ApexClass.Name',
   'ApexClass.NamespacePrefix',
+  'AsyncApexJobId',
+  'Id',
+  'Message',
+  'MethodName',
+  'Outcome',
+  'QueueItemId',
+  'RunTime',
+  'StackTrace',
+  'TestTimestamp',
 ];
 
 export type Outcome = 'Pass' | 'Fail' | 'CompileFail' | 'Skip';
@@ -30,17 +37,17 @@ export interface ApexClass {
 }
 
 export interface BaseTestResult {
-  Outcome: Outcome;
   ApexClass: ApexClass;
-  MethodName: string;
   Message: string | null;
-  StackTrace: string | null;
+  MethodName: string;
+  Outcome: Outcome;
   RunTime: number;
+  StackTrace: string | null;
   TestTimestamp: string;
 }
 
 export interface ApexTestResult extends BaseTestResult {
+  AsyncApexJobId: string;
   Id: string;
   QueueItemId: string;
-  AsyncApexJobId: string;
 }

--- a/src/model/ApexTestRunResult.ts
+++ b/src/model/ApexTestRunResult.ts
@@ -2,31 +2,39 @@
  * Copyright (c) 2019, FinancialForce.com, inc. All rights reserved.
  */
 
+/*
+ Unselected fields:
+  IsAllTests boolean;
+  JobName string;
+  Source string;
+  TestSetupTime: number;
+*/
+
 export const ApexTestRunResultFields = [
   'AsyncApexJobId',
-  'StartTime',
-  'EndTime',
-  'Status',
-  'TestTime',
-  'UserId',
   'ClassesCompleted',
   'ClassesEnqueued',
+  'EndTime',
   'MethodsCompleted',
   'MethodsEnqueued',
   'MethodsFailed',
+  'StartTime',
+  'Status',
+  'TestTime',
+  'UserId',
 ];
 
 export interface ApexTestRunResult {
   Id?: string;
   AsyncApexJobId: string;
-  StartTime: string;
-  EndTime: string;
-  Status: string;
-  TestTime: number;
-  UserId: string;
   ClassesCompleted: number;
   ClassesEnqueued: number;
+  EndTime: string;
   MethodsCompleted: number;
   MethodsEnqueued: number;
   MethodsFailed: number;
+  StartTime: string;
+  Status: string;
+  TestTime: number;
+  UserId: string;
 }

--- a/src/runner/TestRunner.ts
+++ b/src/runner/TestRunner.ts
@@ -264,7 +264,7 @@ export class AsyncTestRunner implements TestRunner {
   private async testResults(testRunId: string): Promise<ApexTestResult[]> {
     return this._queryHelper.query<ApexTestResult>(
       'ApexTestResult',
-      `AsyncApexJobId='${testRunId}'`,
+      `AsyncApexJobId='${testRunId}' AND IsTestSetup=FALSE`,
       ApexTestResultFields.join(', ')
     );
   }


### PR DESCRIPTION
There is an option to turn off `@testSetup` methods generating `ApexTestResult` records in orgs, however this is off by default.

This PR updates the queries to `ApexTestResult` to remove these records, so that re-runs and statistics work as expected.

We could also expose the `TestSetupTime` value in reports, though it is already included in the other times like `RunTime`/`TestTime` so will leave that for another feature update if desired.