### PR TITLE
Add global query retry options setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # test-runner - Changelog
 
+## 3.2.0 - 2024-12-10
+
+* Add `QueryHelper.setGlobalRetryOptions()` static method.
+  * Use to change the retry behaviour of queries across all instances.
+
 ## 3.1.3 - 2024-11-20
 
 * Exclude `@testSetup` methods from `ApexTestResult` queries.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apexdevtools/test-runner",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Apex parallel test runner with reliability goodness",
   "author": {
     "name": "Apex Dev Tools Team",

--- a/src/query/QueryHelper.ts
+++ b/src/query/QueryHelper.ts
@@ -21,6 +21,12 @@ export class QueryHelper {
   retryConfig: { delay?: number; retries?: number };
   logger?: Logger;
 
+  private static globalOptions?: QueryOptions;
+
+  static setGlobalRetryOptions(opts?: QueryOptions) {
+    QueryHelper.globalOptions = opts;
+  }
+
   static instance(
     connection: Connection,
     logger?: Logger,
@@ -37,8 +43,11 @@ export class QueryHelper {
   ) {
     this.connection = connection;
     this.retryConfig = {
-      retries: options.maxQueryRetries,
-      delay: options.queryInitialIntervalMs,
+      retries:
+        options.maxQueryRetries || QueryHelper.globalOptions?.maxQueryRetries,
+      delay:
+        options.queryInitialIntervalMs ||
+        QueryHelper.globalOptions?.queryInitialIntervalMs,
     };
     this.logger = logger;
   }


### PR DESCRIPTION
The default query retry options can appear to make certain classes (e.g. TestMethodCollector) hang when a logger is not used - because the default retry options are 15 secs, 30 secs, 60 secs delays for CI use cases.

Allow overriding the `QueryOptions` globally with `QueryHelper.setGlobalQueryOptions(opts)` (must be imported with `/query/QueryHelper`).