### PR TITLE
fix: publish prereleases with beta tag

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -23,7 +23,11 @@ jobs:
           pnpm install
           pnpm build
           pnpm test
-          pnpm publish --access public --no-git-checks
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            pnpm publish --access public --no-git-checks --tag beta
+          else
+            pnpm publish --access public --no-git-checks
+          fi
 
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the npm publish workflow for prerelease versions.

- publish prerelease GitHub releases with `pnpm publish --tag beta`
- keep normal releases publishing without an explicit tag

This addresses the failure seen when publishing `3.3.1-beta.0`:

> You must specify a tag using --tag when publishing a prerelease version.

## Why

`test-runner` prerelease versions such as `3.3.1-beta.0` cannot be published to npm without an explicit dist-tag. The previous workflow always used the default publish command, which works for stable releases but fails for prereleases.